### PR TITLE
chore: run release on Node v14.17

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14.17
       - name: Install dependencies
         run: npm ci
       - name: Release


### PR DESCRIPTION
as required by semantic release